### PR TITLE
Update to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN apt install gnupg -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fSL "https://bootstrap.pypa.io/get-pip.py" -o get-pip.py \
-    && python3.7 get-pip.py \
-    && python3.8 get-pip.py \
     && python3.9 get-pip.py \
     && python3.10 get-pip.py \
     && rm get-pip.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL author=devteam@level12.io
 
 RUN apt-get clean \
@@ -58,7 +58,7 @@ RUN apt-get update -q && apt-get install -y \
 RUN apt-get update -q \
     && apt-get install -y apt-transport-https ca-certificates \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update -q \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql17 \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Older OS tags may have less recent versions.
 
     - ubuntu1604 (you should upgrade the OS!)
     - ubuntu1804
-    - latest (Ubuntu 20.04)
+    - ubuntu2004
+    - latest (Ubuntu 22.04)
 
 ## Entrypoint
 


### PR DESCRIPTION
- I recommend creating an explicit tag for `2204` in addition to `latest`

Fixes GH-16
